### PR TITLE
Do not use python image due to DockerHub policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the community website with Nikola
-FROM python:3.12 AS builder
+FROM registry.fedoraproject.org/fedora:39 AS builder
 
 # Add the contents of this repository to the working directory
 ADD . /ansible-collaborative
@@ -8,6 +8,7 @@ ADD . /ansible-collaborative
 WORKDIR /ansible-collaborative
 
 # Install Nikola and build the community website
+RUN dnf install -y python3-pip && dnf clean all
 RUN pip install -r requirements.in -c requirements.txt
 RUN nikola build --strict
 


### PR DESCRIPTION
So since we can't easily replace the builder image in Openshift, as using a personal token access for Dockerhub is not great (as they are personal), and since we can't hardcode the Openshift mirror in the FROM (or it would make life harder for the community), the easiest is to use a non limited registry. 

I tested this change and it work, and should prevent any issue with Dockerhub ratelimitation.