### PR TITLE
Restore Matrix .well-known files

### DIFF
--- a/files/.well-known/matrix/client
+++ b/files/.well-known/matrix/client
@@ -1,0 +1,8 @@
+{
+    "m.homeserver": {
+        "base_url": "https://ansible.ems.host"
+    },
+    "m.identity_server": {
+        "base_url": "https://vector.im"
+    }
+}

--- a/files/.well-known/matrix/server
+++ b/files/.well-known/matrix/server
@@ -1,0 +1,3 @@
+{
+    "m.server": "ansible.ems.host:443"
+}


### PR DESCRIPTION
The old Ansible.com served two files from Hubspot that controlled the Matrix domain verification for Ansible.com. These were missed in the migration, so this PR restores them.

More details here: https://matrix-org.github.io/synapse/latest/delegate.html#well-known-delegation