### PR TITLE
fix stretched AAP logo

### DIFF
--- a/templates/homepage-platform-band.tmpl
+++ b/templates/homepage-platform-band.tmpl
@@ -5,8 +5,8 @@
       <div class="platform-box-left">
         <img src="/images/logo-red_hat-aap.png"
              alt="{{ homepage.platform.logo_alt }}"
-             width="250"
-             height="50" />
+             width="230"
+             height="70" />
         <h3>{{ homepage.platform.main }}</h3>
         <p>{{ homepage.platform.discover }}</p>
         <b><a href="{{ homepage.platform.learn_link }}" target="_blank">{{ homepage.platform.learn }}</a>&ensp;<i class="fa fa-arrow-right" aria-hidden="true" /></b>

--- a/themes/ansible-community/sass/_homepage-platform-band.scss
+++ b/themes/ansible-community/sass/_homepage-platform-band.scss
@@ -42,8 +42,9 @@
     font-size: $font-md;
   }
   img {
-    width:200px;
-    height:67px;
+    width:230px;
+    height:70px;
+    object-fit:contain;
     padding-bottom:0px;
     margin-bottom:16px;
   }
@@ -94,18 +95,5 @@
  /* Heading */
   #content .body-content #platform .section-title .platform-row .platform-box-left h3 {
    width:195% !important;
-  }
- 
- /* Image */
-  #platform .platform-box-left img {
-   min-height:67px;
-   min-width:200px;
-  }
-}
-
-@media (max-width:480px) {
-  /* Image */
-  #platform .platform-box-left img {
-   min-height:83px;
   }
 }


### PR DESCRIPTION
small edit to fix the slightly stretched Red Hat Ansible Automation Platform logo

![image](https://github.com/user-attachments/assets/8a429812-4c37-4bde-8a6f-bc0e99573474)
